### PR TITLE
Setting up a grunt release task which publishes the example to gh-pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ pids
 logs
 results
 node_modules
+.grunt/
+build/

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -18,6 +18,10 @@ module.exports = function(grunt) {
 	*/
 	grunt.loadNpmTasks('grunt-contrib-uglify');
 	grunt.loadNpmTasks('grunt-contrib-jshint');
+    grunt.loadNpmTasks('grunt-gh-pages');
+    grunt.loadNpmTasks('grunt-contrib-clean');
+    grunt.loadNpmTasks('grunt-contrib-copy');
+    grunt.loadNpmTasks('grunt-text-replace');
 
 	/**
 	Function that wraps everything to allow dynamically setting/changing grunt options and config later by grunt task. This init function is called once immediately (for using the default grunt options, config, and setup) and then may be called again AFTER updating grunt (command line) options.
@@ -58,10 +62,37 @@ module.exports = function(grunt) {
 					src:    'ng-polymer-elements.js',
 					dest:   'ng-polymer-elements.min.js'
 				}
-			}
+			},
+            clean: {
+                            build: ['build']
+                        },
+                        'gh-pages': {
+                            options: {
+                                base: 'build/example'
+                            },
+                            src: ['**']
+                        },
+                        copy: {
+                            build: {
+                                files: [
+                                    {expand: true, src: ['example/**/*'], dest: 'build/', filter: 'isFile'},
+                                    {src: ['ng-polymer-elements.js'], dest: 'build/example/', filter: 'isFile'}
+                                ]
+                            }
+                        },
+                        replace: {
+                          build: {
+                            src: ['build/example/index.html'],
+                              overwrite: true,
+                            replacements: [{
+                              from: '../ng-polymer-elements.js',
+                              to: 'ng-polymer-elements.js'
+                            }]
+                          }
+                        }
 		});
-		
-		
+
+
 		/**
 		register/define grunt tasks
 		@toc 6.
@@ -69,7 +100,9 @@ module.exports = function(grunt) {
 		// Default task(s).
 		// grunt.registerTask('default', ['jshint:beforeconcat', 'less:development', 'concat:devJs', 'concat:devCss']);
 		grunt.registerTask('default', ['uglify:build']);
-	
+        grunt.registerTask('release', ['clean:build', 'copy:build', 'replace:build', 'gh-pages']);
+
+
 	}
 	init({});		//initialize here for defaults (init may be called again later within a task)
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,11 @@
 	"devDependencies": {
 		"grunt": "~0.4.1",
 		"grunt-contrib-uglify": "~0.2.5",
-		"grunt-contrib-jshint": "~0.7.0"
+		"grunt-contrib-jshint": "~0.7.0",
+        "grunt-contrib-clean": "~0.5.0",
+        "grunt-contrib-copy": "~0.5.0",
+        "grunt-gh-pages": "^0.9.1",
+        "grunt-text-replace": "^0.3.12"
 	},
 	"engines":{
 		"node":"0.10.10"


### PR DESCRIPTION
Publishing the example page to gh-pages
just call: grunt release
see working example on my fork: http://amitit.github.io/ng-polymer-elements/
this will make the example page available under http://gabiaxel.github.io/ng-polymer-elements/
Please don't forget npm install before running grunt release

solves #7
