### PR TITLE
Ingore the example directory

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -14,7 +14,8 @@
 		"node_modules",
 		"bower_components",
 		"test",
-		"tests"
+		"tests",
+		"example"
 	],
 	"dependencies": {
 		"angular": "~1.3.0",


### PR DESCRIPTION
Because otherwise the package contains also the dependencies that will be fetched by Bower.
